### PR TITLE
Feature/add preview configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ you'll need to source again your `~/.tmux.conf` file.
 * [@pass-key](#pass-key)
 * [@pass-copy-to-clipboard](#pass-copy-to-clipboard)
 * [@pass-window-size](#pass-window-size)
+* [@pass-hide-pw-from-preview](#pass-hide-pw-from-preview)
 
 ### @pass-key
 
@@ -93,6 +94,23 @@ For example:
 
 ```bash
 set -g @pass-window-size 10
+```
+
+### @pass-hide-pw-from-preview
+
+```
+default: off
+```
+
+Show only additional information in the preview pane (e.g. login, url, etc.),
+but hide the password itself.  
+This can be desirable in situations when you don't want bystanding people to
+get a glimpse at your passwords.
+
+For example:
+
+```bash
+set -g @pass-hide-pw-from-preview 'on'
 ```
 
 ## Acknowledgements

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ you'll need to source again your `~/.tmux.conf` file.
 * [@pass-copy-to-clipboard](#pass-copy-to-clipboard)
 * [@pass-window-size](#pass-window-size)
 * [@pass-hide-pw-from-preview](#pass-hide-pw-from-preview)
+* [@pass-hide-preview](#pass-hide-preview)
 
 ### @pass-key
 
@@ -111,6 +112,20 @@ For example:
 
 ```bash
 set -g @pass-hide-pw-from-preview 'on'
+```
+
+### @pass-hide-preview
+
+```
+default: off
+```
+
+Start with the preview pane hidden.
+
+For example:
+
+```bash
+set -g @pass-hide-preview
 ```
 
 ## Acknowledgements

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -5,6 +5,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CURRENT_DIR}/utils.sh"
 
 OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@pass-copy-to-clipboard" "off")"
+OPT_HIDE_PREVIEW="$(get_tmux_option "@pass-hide-preview" "off")"
 OPT_HIDE_PW_FROM_PREVIEW="$(get_tmux_option "@pass-hide-pw-from-preview" "off")"
 spinner_pid=""
 
@@ -66,8 +67,13 @@ main() {
   local items
   local sel
   local passwd
-  local header='enter=paste, ctrl-e=edit, ctrl-d=delete'
+  local header='enter=paste, ctrl-e=edit, ctrl-d=delete, tab=preview'
+  local preview_hidden
   local preview_cmd
+
+  if [[ "x$OPT_HIDE_PREVIEW" == "xon" ]]; then
+    preview_hidden='--preview-window=hidden'
+  fi
 
   if [[ "x$OPT_HIDE_PW_FROM_PREVIEW" == "xon" ]]; then
     preview_cmd='pass show {} | tail -n+2'
@@ -84,6 +90,8 @@ main() {
       --inline-info --no-multi \
       --tiebreak=begin \
       --preview="$preview_cmd" \
+      $preview_hidden \
+      --bind=tab:toggle-preview \
       --header="$header" \
       --expect=enter,ctrl-e,ctrl-d,ctrl-c,esc)"
 

--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -5,6 +5,7 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${CURRENT_DIR}/utils.sh"
 
 OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@pass-copy-to-clipboard" "off")"
+OPT_HIDE_PW_FROM_PREVIEW="$(get_tmux_option "@pass-hide-pw-from-preview" "off")"
 spinner_pid=""
 
 # ------------------------------------------------------------------------------
@@ -66,6 +67,13 @@ main() {
   local sel
   local passwd
   local header='enter=paste, ctrl-e=edit, ctrl-d=delete'
+  local preview_cmd
+
+  if [[ "x$OPT_HIDE_PW_FROM_PREVIEW" == "xon" ]]; then
+    preview_cmd='pass show {} | tail -n+2'
+  else
+    preview_cmd='pass show {}'
+  fi
 
   spinner_start "Fetching items"
   items="$(get_items)"
@@ -75,7 +83,7 @@ main() {
     fzf \
       --inline-info --no-multi \
       --tiebreak=begin \
-      --preview='pass show {}' \
+      --preview="$preview_cmd" \
       --header="$header" \
       --expect=enter,ctrl-e,ctrl-d,ctrl-c,esc)"
 


### PR DESCRIPTION
Hello @rafi, first of all: Thanks a lot for this great tmux plugin! 
It works great and is exactly what I was missing from my tmux setup. 

The only thing that bothered me a bit, was that the plugin would start fetching and showing passwords as I type along. 

Therefore I've extended the preview functionality a bit and added some configuration options:

- Added a keybinding (to the `fzf` call) to allow toggling preview-pane visibility with the `TAB`-key, along with a configuration option to control whether the pane should start with preview hidden or visible
- Added a configuration option, which hides the password itself (i.e. the first line) from the preview and only show the rest of the password entry (e.g. login, url, etc.)

Please have a look at the proposed changes and get back to me for any questions or issues. 
It would be great if you could consider merging these changes, so I can switch back to the official version ;-) 

Cheers,
2-Shell