### PR TITLE
feat: read variables set via direnv if direnv exists

### DIFF
--- a/scripts/main.sh
+++ b/scripts/main.sh
@@ -4,6 +4,10 @@ CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=scripts/utils.sh
 source "${CURRENT_DIR}/utils.sh"
 
+if command -v direnv > /dev/null 2>&1; then
+  eval "$(direnv export bash)"
+fi
+
 OPT_COPY_TO_CLIPBOARD="$(get_tmux_option "@pass-copy-to-clipboard" "off")"
 OPT_HIDE_PREVIEW="$(get_tmux_option "@pass-hide-preview" "off")"
 OPT_HIDE_PW_FROM_PREVIEW="$(get_tmux_option "@pass-hide-pw-from-preview" "off")"


### PR DESCRIPTION
:question: What is it about
-----

This allows variables set on a per directory basis via direnv and an `.envrc` file to be taken into account when tmux-pass executes.

:link: Related issues
-----

Relates to #3 